### PR TITLE
Add method type parameters dumping

### DIFF
--- a/Il2CppDumper/Il2Cpp.cs
+++ b/Il2CppDumper/Il2Cpp.cs
@@ -18,6 +18,7 @@ namespace Il2CppDumper
         private Dictionary<ulong, Il2CppType> typesdic = new Dictionary<ulong, Il2CppType>();
         public ulong[] metadataUsages;
         private Il2CppGenericMethodFunctionsDefinitions[] genericMethodTable;
+        public Il2CppGenericInst[] genericInsts;
         public Il2CppMethodSpec[] methodSpecs;
         private Dictionary<int, ulong> genericMethoddDictionary;
         private bool isNew21;
@@ -55,6 +56,7 @@ namespace Il2CppDumper
             pMetadataRegistration = MapVATR<Il2CppMetadataRegistration>(metadataRegistration);
             if (is32Bit)
             {
+                genericInsts = Array.ConvertAll(MapVATR<uint>(pMetadataRegistration.genericInsts, pMetadataRegistration.genericInstsCount), x => MapVATR<Il2CppGenericInst>(x));
                 genericMethodPointers = Array.ConvertAll(MapVATR<uint>(pCodeRegistration.genericMethodPointers, (long)pCodeRegistration.genericMethodPointersCount), x => (ulong)x);
                 invokerPointers = Array.ConvertAll(MapVATR<uint>(pCodeRegistration.invokerPointers, (long)pCodeRegistration.invokerPointersCount), x => (ulong)x);
                 customAttributeGenerators = Array.ConvertAll(MapVATR<uint>(pCodeRegistration.customAttributeGenerators, pCodeRegistration.customAttributeCount), x => (ulong)x);
@@ -103,6 +105,7 @@ namespace Il2CppDumper
             }
             else
             {
+                genericInsts = Array.ConvertAll(MapVATR<ulong>(pMetadataRegistration.genericInsts, pMetadataRegistration.genericInstsCount), x => MapVATR<Il2CppGenericInst>(x));
                 genericMethodPointers = MapVATR<ulong>(pCodeRegistration.genericMethodPointers, (long)pCodeRegistration.genericMethodPointersCount);
                 invokerPointers = MapVATR<ulong>(pCodeRegistration.invokerPointers, (long)pCodeRegistration.invokerPointersCount);
                 customAttributeGenerators = MapVATR<ulong>(pCodeRegistration.customAttributeGenerators, pCodeRegistration.customAttributeCount);


### PR DESCRIPTION
Dump the type parameters of Generic Methods' MethodRef.(for IDA python script)

Examples:
```
Component.GetComponent<RectTransform>() -> Method$Component.GetComponent()_RectTransform_
Dictionary<string,int>.Add() -> Method$Dictionary_string_ int_.Add()
```