### PR TITLE
Fix crash when 2 sections have same name

### DIFF
--- a/Il2CppDumper/Elf.cs
+++ b/Il2CppDumper/Elf.cs
@@ -86,7 +86,11 @@ namespace Il2CppDumper
                 for (uint i = 0; i < elf_header.e_shnum; i++)
                 {
                     var section = ReadClass<Elf32_Shdr>(elf_header.e_shoff + elf_header.e_shentsize * i);
-                    sectionWithName.Add(ReadStringToNull(section_name_block_off + section.sh_name), section);
+					string key = ReadStringToNull(section_name_block_off + section.sh_name);
+                    if(!sectionWithName.ContainsKey(key))
+                    {
+                        sectionWithName.Add(key, section);
+                    }
                 }
             }
             catch

--- a/Il2CppDumper/Elf64.cs
+++ b/Il2CppDumper/Elf64.cs
@@ -75,7 +75,11 @@ namespace Il2CppDumper
                 for (int i = 0; i < elf_header.e_shnum; i++)
                 {
                     var section = ReadClass<Elf64_Shdr>(elf_header.e_shoff + elf_header.e_shentsize * (ulong)i);
-                    sectionWithName.Add(ReadStringToNull(section_name_block_off + section.sh_name), section);
+                    string key = ReadStringToNull(section_name_block_off + section.sh_name);
+                    if(!sectionWithName.ContainsKey(key))
+                    {
+                        sectionWithName.Add(key, section);
+                    }
                 }
             }
             catch


### PR DESCRIPTION
proof:
![image](https://user-images.githubusercontent.com/17663689/73436746-0feb9f00-4386-11ea-8681-e171fc01fe9d.png)
