### PR TITLE
Allow Il2CppDumper uses raw memory & Make GetMethodPointer not throwing

### DIFF
--- a/Il2CppDumper/ExecutableFormats/Il2Cpp.cs
+++ b/Il2CppDumper/ExecutableFormats/Il2Cpp.cs
@@ -212,9 +212,17 @@ namespace Il2CppDumper
                 }
                 else
                 {
-                    var ptrs = codeGenModuleMethodPointers[imageIndex];
-                    var methodPointerIndex = methodToken & 0x00FFFFFFu;
-                    return ptrs[methodPointerIndex - 1];
+                    if (imageIndex < codeGenModuleMethodPointers.Length)
+                    {
+                        var ptrs = codeGenModuleMethodPointers[imageIndex];
+                        var methodPointerIndex = methodToken & 0x00FFFFFFu;
+                        return ptrs[methodPointerIndex - 1];
+                    }
+                    else
+                    {
+                        return 0UL;
+                    }
+                    
                 }
             }
             else

--- a/Il2CppDumper/ExecutableFormats/Raw.cs
+++ b/Il2CppDumper/ExecutableFormats/Raw.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+
+namespace Il2CppDumper
+{
+    public sealed class Raw : Il2Cpp
+    {
+        private ulong baseAddr;
+        public Raw(Stream stream, ulong baseAddr, bool is64bit, float version, long maxMetadataUsages) : base(stream, version, maxMetadataUsages)
+        {
+            Is32Bit = !is64bit;
+            this.baseAddr = baseAddr;
+        }
+        public override ulong MapVATR(ulong absAddr)
+        {
+            return absAddr - baseAddr;
+        }
+
+        public override bool Search()
+        {
+            return false;
+        }
+
+        public override bool PlusSearch(int methodCount, int typeDefinitionsCount)
+        {
+            return false;
+        }
+
+        public override bool SymbolSearch()
+        {
+            return false;
+        }
+
+        public override ulong GetRVA(ulong pointer)
+        {
+            return pointer - baseAddr;
+        }
+    }
+}


### PR DESCRIPTION
There're still some executable format Il2CppDumper can't handle, such as WASM. Also, when we retrived a memory dump, sometimes we cannot rebuild the executable file headers. 
For these scenarios, it would be great to support loading raw memory and make Il2CppDumper work in manual mode.

Also, the Il2Cpp::GetMethodPointer is not working on some Unity 2020 compiled binary, which has no ```CodeGenModules```, I've added a check in that function.