### PR TITLE
Add config option to not require key press

### DIFF
--- a/Il2CppDumper/Config.cs
+++ b/Il2CppDumper/Config.cs
@@ -16,6 +16,7 @@ namespace Il2CppDumper
         public bool DumpTypeDefIndex = true;
         public bool DummyDll = true;
         public bool MakeFunction = false;
+        public bool RequireAnyKey = true;
         public bool ForceIl2CppVersion = false;
         public float ForceVersion = 24.3f;
     }

--- a/Il2CppDumper/Program.cs
+++ b/Il2CppDumper/Program.cs
@@ -87,8 +87,10 @@ namespace Il2CppDumper
             {
                 Console.WriteLine(e);
             }
-            Console.WriteLine("Press any key to exit...");
-            Console.ReadKey(true);
+            if (config.RequireAnyKey) {
+                Console.WriteLine("Press any key to exit...");
+                Console.ReadKey(true);
+            }
         }
 
         static void ShowHelp()

--- a/Il2CppDumper/config.json
+++ b/Il2CppDumper/config.json
@@ -8,6 +8,7 @@
   "DumpTypeDefIndex": true,
   "DummyDll": true,
   "MakeFunction": true,
+  "RequireAnyKey": true,
   "ForceIl2CppVersion": false,
   "ForceVersion": 24.3
 }


### PR DESCRIPTION
Default behavior is to maintain existing "press any key" prompt.  With the config option set to false, it does not require further input and allows automated tools to invoke the program without needing to handle the final interaction.  When invoked in a non-interactive context, the input requirement can cause tools to think the command encountered a fatal error when it actually didn't.