### PR TITLE
Python 脚本导入字段可配置

### DIFF
--- a/Il2CppDumper/ghidra.py
+++ b/Il2CppDumper/ghidra.py
@@ -39,10 +39,10 @@ data = json.loads(open(f.absolutePath, 'rb').read().decode('utf-8'))
 
 if "ScriptMethod" in data and "ScriptMethod" in processFields:
 	scriptMethods = data["ScriptMethod"]
-		for scriptMethod in scriptMethods:
-			addr = get_addr(scriptMethod["Address"])
-			name = scriptMethod["Name"].encode("utf-8")
-			set_name(addr, name)
+	for scriptMethod in scriptMethods:
+		addr = get_addr(scriptMethod["Address"])
+		name = scriptMethod["Name"].encode("utf-8")
+		set_name(addr, name)
 
 if "ScriptString" in data and "ScriptString" in processFields:
 	index = 1

--- a/Il2CppDumper/ghidra.py
+++ b/Il2CppDumper/ghidra.py
@@ -1,6 +1,14 @@
 # -*- coding: utf-8 -*-
 import json
 
+processFields = [
+	"ScriptMethod",
+	"ScriptString",
+	"ScriptMetadata",
+	"ScriptMetadataMethod",
+	"Addresses",
+]
+
 functionManager = currentProgram.getFunctionManager()
 baseAddress = currentProgram.getImageBase()
 USER_DEFINED = ghidra.program.model.symbol.SourceType.USER_DEFINED
@@ -28,36 +36,48 @@ def make_function(start, end):
 print 'Script: Edit config.json and set MakeFunction to false to speed up ghidra script execution'
 f = askFile("script.json from Il2cppdumper", "Open")
 data = json.loads(open(f.absolutePath, 'rb').read().decode('utf-8'))
-scriptMethods = data["ScriptMethod"]
-for scriptMethod in scriptMethods:
-	addr = get_addr(scriptMethod["Address"])
-	name = scriptMethod["Name"].encode("utf-8")
-	set_name(addr, name)
-index = 1
-scriptStrings = data["ScriptString"]
-for scriptString in scriptStrings:
-	addr = get_addr(scriptString["Address"])
-	value = scriptString["Value"].encode("utf-8")
-	name = "StringLiteral_" + str(index)
-	createLabel(addr, name, True, USER_DEFINED)
-	setEOLComment(addr, value)
-	index += 1
-scriptMetadatas = data["ScriptMetadata"]
-for scriptMetadata in scriptMetadatas:
-	addr = get_addr(scriptMetadata["Address"])
-	name = scriptMetadata["Name"].encode("utf-8")
-	set_name(addr, name)
-	setEOLComment(addr, name)
-scriptMetadataMethods = data["ScriptMetadataMethod"]
-for scriptMetadataMethod in scriptMetadataMethods:
-	addr = get_addr(scriptMetadataMethod["Address"])
-	name = scriptMetadataMethod["Name"].encode("utf-8")
-	methodAddr = get_addr(scriptMetadataMethod["MethodAddress"])
-	set_name(addr, name)
-	setEOLComment(addr, name)
-addresses = data["Addresses"]
-for index in range(len(addresses) - 1):
-	start = get_addr(addresses[index])
-	end = get_addr(addresses[index + 1])
-	make_function(start, end)
+
+if "ScriptMethod" in data and "ScriptMethod" in processFields:
+	scriptMethods = data["ScriptMethod"]
+		for scriptMethod in scriptMethods:
+			addr = get_addr(scriptMethod["Address"])
+			name = scriptMethod["Name"].encode("utf-8")
+			set_name(addr, name)
+
+if "ScriptString" in data and "ScriptString" in processFields:
+	index = 1
+	scriptStrings = data["ScriptString"]
+	for scriptString in scriptStrings:
+		addr = get_addr(scriptString["Address"])
+		value = scriptString["Value"].encode("utf-8")
+		name = "StringLiteral_" + str(index)
+		createLabel(addr, name, True, USER_DEFINED)
+		setEOLComment(addr, value)
+		index += 1
+
+if "ScriptMetadata" in data and "ScriptMetadata" in processFields:
+	scriptMetadatas = data["ScriptMetadata"]
+	for scriptMetadata in scriptMetadatas:
+		addr = get_addr(scriptMetadata["Address"])
+		name = scriptMetadata["Name"].encode("utf-8")
+		set_name(addr, name)
+		setEOLComment(addr, name)
+
+if "ScriptMetadataMethod" in data and "ScriptMetadataMethod" in processFields:
+	scriptMetadataMethods = data["ScriptMetadataMethod"]
+	for scriptMetadataMethod in scriptMetadataMethods:
+		addr = get_addr(scriptMetadataMethod["Address"])
+		name = scriptMetadataMethod["Name"].encode("utf-8")
+		methodAddr = get_addr(scriptMetadataMethod["MethodAddress"])
+		set_name(addr, name)
+		setEOLComment(addr, name)
+
+if "Addresses" in data and "Addresses" in processFields:
+	addresses = data["Addresses"]
+	for index in range(len(addresses) - 1):
+		start = get_addr(addresses[index])
+		end = get_addr(addresses[index + 1])
+		make_function(start, end)
+
 print 'Script finished!'
+

--- a/Il2CppDumper/ida.py
+++ b/Il2CppDumper/ida.py
@@ -1,6 +1,14 @@
 # -*- coding: utf-8 -*-
 import json
 
+processFields = [
+	"ScriptMethod",
+	"ScriptString",
+	"ScriptMetadata",
+	"ScriptMetadataMethod",
+	"Addresses",
+]
+
 imageBase = idaapi.get_imagebase()
 
 def get_addr(addr):
@@ -22,37 +30,49 @@ def make_function(start, end):
 
 path = idaapi.ask_file(False, '*.json', 'script.json from Il2cppdumper')
 data = json.loads(open(path, 'rb').read().decode('utf-8'))
-scriptMethods = data["ScriptMethod"]
-for scriptMethod in scriptMethods:
-	addr = get_addr(scriptMethod["Address"])
-	name = scriptMethod["Name"].encode("utf-8")
-	set_name(addr, name)
-index = 1
-scriptStrings = data["ScriptString"]
-for scriptString in scriptStrings:
-	addr = get_addr(scriptString["Address"])
-	value = scriptString["Value"].encode("utf-8")
-	name = "StringLiteral_" + str(index)
-	idc.set_name(addr, name, SN_NOWARN)
-	idc.set_cmt(addr, value, 1)
-	index += 1
-scriptMetadatas = data["ScriptMetadata"]
-for scriptMetadata in scriptMetadatas:
-	addr = get_addr(scriptMetadata["Address"])
-	name = scriptMetadata["Name"].encode("utf-8")
-	set_name(addr, name)
-	idc.set_cmt(addr, name, 1)
-scriptMetadataMethods = data["ScriptMetadataMethod"]
-for scriptMetadataMethod in scriptMetadataMethods:
-	addr = get_addr(scriptMetadataMethod["Address"])
-	name = scriptMetadataMethod["Name"].encode("utf-8")
-	methodAddr = get_addr(scriptMetadataMethod["MethodAddress"])
-	set_name(addr, name)
-	idc.set_cmt(addr, name, 1)
-	idc.set_cmt(addr, '{0:X}'.format(methodAddr), 0)
-addresses = data["Addresses"]
-for index in range(len(addresses) - 1):
-	start = get_addr(addresses[index])
-	end = get_addr(addresses[index + 1])
-	make_function(start, end)
+
+if "ScriptMethod" in data and "ScriptMethod" in processFields:
+	scriptMethods = data["ScriptMethod"]
+	for scriptMethod in scriptMethods:
+		addr = get_addr(scriptMethod["Address"])
+		name = scriptMethod["Name"].encode("utf-8")
+		set_name(addr, name)
+
+if "ScriptString" in data and "ScriptString" in processFields:
+	index = 1
+	scriptStrings = data["ScriptString"]
+	for scriptString in scriptStrings:
+		addr = get_addr(scriptString["Address"])
+		value = scriptString["Value"].encode("utf-8")
+		name = "StringLiteral_" + str(index)
+		idc.set_name(addr, name, SN_NOWARN)
+		idc.set_cmt(addr, value, 1)
+		index += 1
+
+if "ScriptMetadata" in data and "ScriptMetadata" in processFields:
+	scriptMetadatas = data["ScriptMetadata"]
+	for scriptMetadata in scriptMetadatas:
+		addr = get_addr(scriptMetadata["Address"])
+		name = scriptMetadata["Name"].encode("utf-8")
+		set_name(addr, name)
+		idc.set_cmt(addr, name, 1)
+
+if "ScriptMetadataMethod" in data and "ScriptMetadataMethod" in processFields:
+	scriptMetadataMethods = data["ScriptMetadataMethod"]
+	for scriptMetadataMethod in scriptMetadataMethods:
+		addr = get_addr(scriptMetadataMethod["Address"])
+		name = scriptMetadataMethod["Name"].encode("utf-8")
+		methodAddr = get_addr(scriptMetadataMethod["MethodAddress"])
+		set_name(addr, name)
+		idc.set_cmt(addr, name, 1)
+		idc.set_cmt(addr, '{0:X}'.format(methodAddr), 0)
+
+if "Addresses" in data and "Addresses" in processFields:
+	addresses = data["Addresses"]
+	for index in range(len(addresses) - 1):
+		start = get_addr(addresses[index])
+		end = get_addr(addresses[index + 1])
+		make_function(start, end)
+
 print 'Script finished!'
+

--- a/Il2CppDumper/ida_with_struct.py
+++ b/Il2CppDumper/ida_with_struct.py
@@ -1,6 +1,14 @@
 # -*- coding: utf-8 -*-
 import json
 
+processFields = [
+	"ScriptMethod",
+	"ScriptString",
+	"ScriptMetadata",
+	"ScriptMetadataMethod",
+	"Addresses",
+]
+
 imageBase = idaapi.get_imagebase()
 
 def get_addr(addr):
@@ -24,45 +32,56 @@ path = idaapi.ask_file(False, '*.json', 'script.json from Il2cppdumper')
 hpath = idaapi.ask_file(False, '*.h', 'il2cpp.h from Il2cppdumper')
 parse_decls(open(hpath, 'rb').read(), 0)
 data = json.loads(open(path, 'rb').read().decode('utf-8'))
-scriptMethods = data["ScriptMethod"]
-for scriptMethod in scriptMethods:
-	addr = get_addr(scriptMethod["Address"])
-	name = scriptMethod["Name"].encode("utf-8")
-	set_name(addr, name)
-	signature = scriptMethod["Signature"].encode("utf-8")
-	if apply_type(addr, parse_decl(signature, 0), 1) == False:
-		print "apply_type failed:", hex(addr), signature
-index = 1
-scriptStrings = data["ScriptString"]
-for scriptString in scriptStrings:
-	addr = get_addr(scriptString["Address"])
-	value = scriptString["Value"].encode("utf-8")
-	name = "StringLiteral_" + str(index)
-	idc.set_name(addr, name, SN_NOWARN)
-	idc.set_cmt(addr, value, 1)
-	index += 1
-scriptMetadatas = data["ScriptMetadata"]
-for scriptMetadata in scriptMetadatas:
-	addr = get_addr(scriptMetadata["Address"])
-	name = scriptMetadata["Name"].encode("utf-8")
-	set_name(addr, name)
-	idc.set_cmt(addr, name, 1)
-	if scriptMetadata["Signature"] is not None:
-		signature = scriptMetadata["Signature"].encode("utf-8")
+
+if "ScriptMethod" in data and "ScriptMethod" in processFields:
+	scriptMethods = data["ScriptMethod"]
+	for scriptMethod in scriptMethods:
+		addr = get_addr(scriptMethod["Address"])
+		name = scriptMethod["Name"].encode("utf-8")
+		set_name(addr, name)
+		signature = scriptMethod["Signature"].encode("utf-8")
 		if apply_type(addr, parse_decl(signature, 0), 1) == False:
 			print "apply_type failed:", hex(addr), signature
 
-scriptMetadataMethods = data["ScriptMetadataMethod"]
-for scriptMetadataMethod in scriptMetadataMethods:
-	addr = get_addr(scriptMetadataMethod["Address"])
-	name = scriptMetadataMethod["Name"].encode("utf-8")
-	methodAddr = get_addr(scriptMetadataMethod["MethodAddress"])
-	set_name(addr, name)
-	idc.set_cmt(addr, name, 1)
-	idc.set_cmt(addr, '{0:X}'.format(methodAddr), 0)
-addresses = data["Addresses"]
-for index in range(len(addresses) - 1):
-	start = get_addr(addresses[index])
-	end = get_addr(addresses[index + 1])
-	make_function(start, end)
+if "ScriptString" in data and "ScriptString" in processFields:
+	index = 1
+	scriptStrings = data["ScriptString"]
+	for scriptString in scriptStrings:
+		addr = get_addr(scriptString["Address"])
+		value = scriptString["Value"].encode("utf-8")
+		name = "StringLiteral_" + str(index)
+		idc.set_name(addr, name, SN_NOWARN)
+		idc.set_cmt(addr, value, 1)
+		index += 1
+
+if "ScriptMetadata" in data and "ScriptMetadata" in processFields:
+	scriptMetadatas = data["ScriptMetadata"]
+	for scriptMetadata in scriptMetadatas:
+		addr = get_addr(scriptMetadata["Address"])
+		name = scriptMetadata["Name"].encode("utf-8")
+		set_name(addr, name)
+		idc.set_cmt(addr, name, 1)
+		if scriptMetadata["Signature"] is not None:
+			signature = scriptMetadata["Signature"].encode("utf-8")
+			if apply_type(addr, parse_decl(signature, 0), 1) == False:
+				print "apply_type failed:", hex(addr), signature
+
+if "ScriptMetadataMethod" in data and "ScriptMetadataMethod" in processFields:
+	scriptMetadataMethods = data["ScriptMetadataMethod"]
+	for scriptMetadataMethod in scriptMetadataMethods:
+		addr = get_addr(scriptMetadataMethod["Address"])
+		name = scriptMetadataMethod["Name"].encode("utf-8")
+		methodAddr = get_addr(scriptMetadataMethod["MethodAddress"])
+		set_name(addr, name)
+		idc.set_cmt(addr, name, 1)
+		idc.set_cmt(addr, '{0:X}'.format(methodAddr), 0)
+
+if "Addresses" in data and "Addresses" in processFields:
+	addresses = data["Addresses"]
+	for index in range(len(addresses) - 1):
+		start = get_addr(addresses[index])
+		end = get_addr(addresses[index + 1])
+		make_function(start, end)
+
 print 'Script finished!'
+


### PR DESCRIPTION
遇到了一个混淆工具，处理后的binary dump出来的函数地址都是错的，但是字符串是对的。

加了个配置数组，允许只处理部分字段。

本来想试试ida的form，以后再说