### PR TITLE
Fix for #324

### DIFF
--- a/Il2CppDumper/Il2Cpp/Metadata.cs
+++ b/Il2CppDumper/Il2Cpp/Metadata.cs
@@ -251,5 +251,16 @@ namespace Il2CppDumper
                 }
             }
         }
+
+        internal string ReadString(int numChars)
+        {
+            var start = Position;
+            // UTF8 takes up to 4 bytes per character
+            var str = Encoding.UTF8.GetString(ReadBytes(numChars * 4)).Substring(0, numChars);
+            // make our position what it would have been if we'd known the exact number of bytes needed.
+            Position = start;
+            ReadBytes(Encoding.UTF8.GetByteCount(str));
+            return str;
+        }
     }
 }

--- a/Il2CppDumper/Outputs/Il2CppDecompiler.cs
+++ b/Il2CppDumper/Outputs/Il2CppDecompiler.cs
@@ -501,7 +501,7 @@ namespace Il2CppDumper
                     return true;
                 case Il2CppTypeEnum.IL2CPP_TYPE_STRING:
                     var len = metadata.ReadInt32();
-                    value = Encoding.UTF8.GetString(metadata.ReadBytes(len));
+                    value = metadata.ReadString(len);
                     return true;
                 default:
                     value = pointer;

--- a/Il2CppDumper/Utils/DummyAssemblyGenerator.cs
+++ b/Il2CppDumper/Utils/DummyAssemblyGenerator.cs
@@ -556,7 +556,7 @@ namespace Il2CppDumper
                     return true;
                 case Il2CppTypeEnum.IL2CPP_TYPE_STRING:
                     var len = metadata.ReadInt32();
-                    value = Encoding.UTF8.GetString(metadata.ReadBytes(len));
+                    value = metadata.ReadString(len);
                     return true;
                 default:
                     value = pointer;


### PR DESCRIPTION
(I wasn't sure if the position afterwards was important. If it's not, you can obviously just skip the 2nd half of the function and just return str.)