### PR TITLE
Add token attributes to dummy dll

### DIFF
--- a/Il2CppDumper/Utils/DummyAssemblyGenerator.cs
+++ b/Il2CppDumper/Utils/DummyAssemblyGenerator.cs
@@ -32,6 +32,7 @@ namespace Il2CppDumper
             var fieldOffsetAttribute = il2CppDummyDll.MainModule.Types.First(x => x.Name == "FieldOffsetAttribute").Methods[0];
             attributeAttribute = il2CppDummyDll.MainModule.Types.First(x => x.Name == "AttributeAttribute").Methods[0];
             var metadataOffsetAttribute = il2CppDummyDll.MainModule.Types.First(x => x.Name == "MetadataOffsetAttribute").Methods[0];
+            var tokenAttribute = il2CppDummyDll.MainModule.Types.First(x => x.Name == "TokenAttribute").Methods[0];
             stringType = il2CppDummyDll.MainModule.TypeSystem.String;
 
             var resolver = new MyAssemblyResolver();
@@ -91,6 +92,11 @@ namespace Il2CppDumper
             {
                 var typeDef = metadata.typeDefs[index];
                 var typeDefinition = typeDefinitionDic[index];
+                
+                var customAttribute = new CustomAttribute(typeDefinition.Module.ImportReference(tokenAttribute));
+                customAttribute.Fields.Add(new CustomAttributeNamedArgument("Token", new CustomAttributeArgument(stringType, $"0x{typeDef.token:X}")));
+                typeDefinition.CustomAttributes.Add(customAttribute);
+                
                 //parent
                 if (typeDef.parentIndex >= 0)
                 {
@@ -127,6 +133,11 @@ namespace Il2CppDumper
                         var fieldDefinition = new FieldDefinition(fieldName, (FieldAttributes)fieldType.attrs, fieldTypeRef);
                         typeDefinition.Fields.Add(fieldDefinition);
                         fieldDefinitionDic.Add(i, fieldDefinition);
+                        
+                        var customTokenAttribute = new CustomAttribute(typeDefinition.Module.ImportReference(tokenAttribute));
+                        customTokenAttribute.Fields.Add(new CustomAttributeNamedArgument("Token", new CustomAttributeArgument(stringType, $"0x{fieldDef.token:X}")));
+                        fieldDefinition.CustomAttributes.Add(customTokenAttribute);
+                        
                         //fieldDefault
                         if (metadata.GetFieldDefaultValueFromIndex(i, out var fieldDefault) && fieldDefault.dataIndex != -1)
                         {
@@ -167,6 +178,11 @@ namespace Il2CppDumper
                         var methodReturnType = il2Cpp.types[methodDef.returnType];
                         var returnType = GetTypeReferenceWithByRef(methodDefinition, methodReturnType);
                         methodDefinition.ReturnType = returnType;
+                        
+                        var customTokenAttribute = new CustomAttribute(typeDefinition.Module.ImportReference(tokenAttribute));
+                        customTokenAttribute.Fields.Add(new CustomAttributeNamedArgument("Token", new CustomAttributeArgument(stringType, $"0x{methodDef.token:X}")));
+                        methodDefinition.CustomAttributes.Add(customTokenAttribute);
+                        
                         if (methodDefinition.HasBody && typeDefinition.BaseType?.FullName != "System.MulticastDelegate")
                         {
                             var ilprocessor = methodDefinition.Body.GetILProcessor();
@@ -286,6 +302,10 @@ namespace Il2CppDumper
                         };
                         typeDefinition.Properties.Add(propertyDefinition);
                         propertyDefinitionDic.Add(i, propertyDefinition);
+                        
+                        var customTokenAttribute = new CustomAttribute(typeDefinition.Module.ImportReference(tokenAttribute));
+                        customTokenAttribute.Fields.Add(new CustomAttributeNamedArgument("Token", new CustomAttributeArgument(stringType, $"0x{propertyDef.token:X}")));
+                        propertyDefinition.CustomAttributes.Add(customTokenAttribute);
                     }
                     //event
                     var eventEnd = typeDef.eventStart + typeDef.event_count;
@@ -304,6 +324,10 @@ namespace Il2CppDumper
                             eventDefinition.InvokeMethod = methodDefinitionDic[typeDef.methodStart + eventDef.raise];
                         typeDefinition.Events.Add(eventDefinition);
                         eventDefinitionDic.Add(i, eventDefinition);
+                        
+                        var customTokenAttribute = new CustomAttribute(typeDefinition.Module.ImportReference(tokenAttribute));
+                        customTokenAttribute.Fields.Add(new CustomAttributeNamedArgument("Token", new CustomAttributeArgument(stringType, $"0x{eventDef.token:X}")));
+                        eventDefinition.CustomAttributes.Add(customTokenAttribute);
                     }
                     //补充泛型参数
                     if (typeDef.genericContainerIndex >= 0)

--- a/Il2CppDumper/Utils/Il2CppDummyDll.cs
+++ b/Il2CppDumper/Utils/Il2CppDummyDll.cs
@@ -48,6 +48,10 @@ namespace Il2CppDumper
             metadataOffsetAttribute.Fields.Add(new FieldDefinition("Offset", FieldAttributes.Public, stringTypeReference));
             types.Add(metadataOffsetAttribute);
             CreateDefaultConstructor(metadataOffsetAttribute);
+            var tokenAttribute = new TypeDefinition(namespaceName, "TokenAttribute", (TypeAttributes)0x100001, attributeTypeReference);
+            tokenAttribute.Fields.Add(new FieldDefinition("Token", FieldAttributes.Public, stringTypeReference));
+            types.Add(tokenAttribute);
+            CreateDefaultConstructor(tokenAttribute);
             return assemblyDefinition;
         }
 


### PR DESCRIPTION
Motivation: this would make it easier to work with il2cpp API at runtime, as tokens provide a nice and performant way to uniquely identify classes/methods without ambiguity of names and difficulties of overload resolution.
Mainly this would allow to generate better-performing assemblies using future versions of my [assembly unhollower](https://github.com/knah/Il2CppAssemblyUnhollower) that could make use of token information