### PR TITLE
Add brief notes on building under some "non-standard" .NET environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ Unity il2cpp reverse engineer
 * Supports Android memory dumped `libil2cpp.so` file to bypass protection
 * Support bypassing simple PE protection
 
+## Build
+
+Just build it the normal way. In case it fails or you have non-standard .NET environment, see below.
+
+### .NET Core only (useful on Linux)
+
+```sh
+dotnet build -f netcoreapp3.1 -c Release
+```
+
+### Mono (using .NET Framework and mono-msbuild)
+
+```sh
+nuget restore
+msbuild /p:TargetFramework=net472,Configuration=Release
+```
+
 ## Usage
 
 Run `Il2CppDumper.exe` and choose the il2cpp executable file and `global-metadata.dat` file, then enter the information as prompted

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,23 @@ Unity il2cpp逆向工程
 * 支持从内存dump的`libil2cpp.so`文件以绕过保护
 * 支持绕过简单的PE保护
 
+## 编译
+
+直接按照普通.NET项目的编译方法编译即可。如遇到问题或者你的.NET环境非标准，请参考以下：
+
+### 仅针对.NET Core（适用于Linux环境）
+
+```sh
+dotnet build -f netcoreapp3.1 -c Release
+```
+
+### Mono（使用Mono的.NET Framework和msbuild实现）
+
+```sh
+nuget restore
+msbuild /p:TargetFramework=net472,Configuration=Release
+```
+
 ## 使用说明
 
 直接运行Il2CppDumper.exe并依次选择il2cpp的可执行文件和global-metadata.dat文件，然后根据提示输入相应信息。


### PR DESCRIPTION
Includes .NET Core under non-Windows environment (which will have .NET Framework missing) and Mono (only supports .NET Framework at the moment).