### PR TITLE
Make il2cpp.h compatible with ghidra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,6 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
+.vscode/launch.json
+.vscode/tasks.json
+.gitignore

--- a/Il2CppDumper/Outputs/HeaderConstants.cs
+++ b/Il2CppDumper/Outputs/HeaderConstants.cs
@@ -3,7 +3,18 @@
     public static class HeaderConstants
     {
         public readonly static string GenericHeader =
-@"typedef void(*Il2CppMethodPointer)();
+@"typedef int intptr_t;
+typedef uint uintptr_t;
+typedef uchar uint8_t;
+typedef char int8_t;
+typedef short int16_t;
+typedef ushort uint16_t;
+typedef int int32_t;
+typedef uint uint32_t;
+typedef longlong int64_t;
+typedef ulonglong uint64_t;
+
+typedef void(*Il2CppMethodPointer)();
 
 struct MethodInfo;
 


### PR DESCRIPTION
Per #287 include necessary initial typedefs and modify header file generation to inline all fields rather than include C++-style inheritance. This maintains internal (il2cppdumper) link to Parent class but necessarily removes obvious struct link to parent.