### PR TITLE
Make il2cpp.h compatible with ghidra

### DIFF
--- a/Il2CppDumper/Outputs/HeaderConstants.cs
+++ b/Il2CppDumper/Outputs/HeaderConstants.cs
@@ -3,7 +3,18 @@
     public static class HeaderConstants
     {
         public readonly static string GenericHeader =
-@"typedef void(*Il2CppMethodPointer)();
+@"typedef int intptr_t;
+typedef uint uintptr_t;
+typedef uchar uint8_t;
+typedef char int8_t;
+typedef short int16_t;
+typedef ushort uint16_t;
+typedef int int32_t;
+typedef uint uint32_t;
+typedef longlong int64_t;
+typedef ulonglong uint64_t;
+
+typedef void(*Il2CppMethodPointer)();
 
 struct MethodInfo;
 

--- a/Il2CppDumper/Outputs/ScriptGenerator.cs
+++ b/Il2CppDumper/Outputs/ScriptGenerator.cs
@@ -733,21 +733,18 @@ namespace Il2CppDumper
 
             var sb = new StringBuilder();
             var pre = new StringBuilder();
-            Stack<string> parents = new Stack<string>();
-            List<StructFieldInfo> allFields = new List<StructFieldInfo>();
+
             if (info.Parent != null)
             {
-                string parent = info.Parent;
-                while ( ! String.IsNullOrEmpty(parent) ) {
-                    var parentStructName = parent + "_o";
-                    pre.Append(RecursionStructInfo(structInfoWithStructName[parentStructName]));
-                    parents.Push(parent);
-                    parent = structInfoWithStructName[parent + "_o"].Parent;
-                }
-                sb.Append($"struct {info.TypeName}_Fields {{\n");
+                var parentStructName = info.Parent + "_o";
+                pre.Append(RecursionStructInfo(structInfoWithStructName[parentStructName]));
+                // C++ style
+                //sb.Append($"struct {info.TypeName}_Fields : {info.Parent}_Fields {{\n");
                 // C style
-                //sb.Append($"struct {info.TypeName}_Fields {{\n");
-                //sb.Append($"\t{info.Parent}_Fields _;\n");
+                sb.Append($"struct {info.TypeName}_Fields {{\n");
+                if (structInfoWithStructName[parentStructName].Fields.Count() != 0) {
+                    sb.Append($"\t{info.Parent}_Fields _;\n");
+                }
             }
             else
             {
@@ -767,14 +764,7 @@ namespace Il2CppDumper
                     sb.Append($"struct {info.TypeName}_Fields {{\n");
                 }
             }
-            while ( parents.Count > 0 ) 
-            {
-                string parent = parents.Pop();
-                allFields.AddRange(structInfoWithStructName[parent + "_o"].Fields);
-            }
-            allFields.AddRange(info.Fields);
-
-            foreach (var field in allFields)
+            foreach (var field in info.Fields)
             {
                 if (field.IsValueType)
                 {


### PR DESCRIPTION
Per #287  
Add necessary typedefs to header file & inline all fields rather than use C++-style inheritance. Internally maintains Il2Cppdumper link to base (Parent) class, but struct is no longer explicitly associated with the base.

In my testing works fine in ghidra, needs further testing to ensure it doesn't break parsing by IDA