### PR TITLE
Simplify ghidra.py make_function

### DIFF
--- a/Il2CppDumper/ghidra.py
+++ b/Il2CppDumper/ghidra.py
@@ -20,18 +20,10 @@ def set_name(addr, name):
 	name = name.replace(' ', '-')
 	createLabel(addr, name, True, USER_DEFINED)
 
-def make_function(start, end):
-	next_func_start = getFunctionAfter(start).getEntryPoint()
-	if next_func_start < end:
-		end = next_func_start
-	body = createAddressSet()
-	body.addRange(start, end.subtract(1))
-	functionManager.deleteAddressRange(start, end.subtract(1), getMonitor())
+def make_function(start):
 	func = getFunctionAt(start)
 	if func is None:
-		functionManager.createFunction(None, start, body, USER_DEFINED)
-	else:
-		func.setBody(body)
+		createFunction(start, None)
 
 f = askFile("script.json from Il2cppdumper", "Open")
 data = json.loads(open(f.absolutePath, 'rb').read().decode('utf-8'))
@@ -75,8 +67,7 @@ if "Addresses" in data and "Addresses" in processFields:
 	addresses = data["Addresses"]
 	for index in range(len(addresses) - 1):
 		start = get_addr(addresses[index])
-		end = get_addr(addresses[index + 1])
-		make_function(start, end)
+		make_function(start)
 
 print 'Script finished!'
 


### PR DESCRIPTION
As noted in #374 ghidra.py is quite slow for large programs due to the getFunctionAfter(start) search. This helps mitigate creating overlapping functions which throws an exception. However, functions in the listing may be fragmented and there are many other ways setting the body to (set, end-1) may overlap existing functions. This is further mitigated in existing code via the deleteAddressRange call, which will remove data defined (by user or otherwise) prior to running the script. Additionally, (start,end-1) is far from certain to be the function body; even if the function is not fragmented in the listing, it may end well before the next function/address.

These problems may be removed by simplifying the function creation to creating it without a defined body.

This does not break the disassembling or decompiling of the function, but does show the "function length" as 1 in the Function Manager. This is fixed by running an auto-analysis (even with all options deselected) or via the "re-create function" command.

My only uncertainty here is that last bit; it's uncertain how long it takes to do so but the program can still be used while auto-analysis is ongoing. Should this be programmatically done somehow? Is it useful to have the (inaccurate) lengths of (start,end-1) earlier instead? (Even if we choose not to simplify it this way, we can still significantly speed up the script by avoiding the getFunctionAfter() call except when needed.) Happy to discuss.