### PR TITLE
支持对 WebAssembly 的分析

### DIFF
--- a/Il2CppDumper/Il2CppDumper.csproj
+++ b/Il2CppDumper/Il2CppDumper.csproj
@@ -25,6 +25,9 @@
     <None Update="ghidra.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="ghidra_wasm.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="ghidra_with_struct.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Il2CppDumper/Outputs/ScriptJson.cs
+++ b/Il2CppDumper/Outputs/ScriptJson.cs
@@ -21,6 +21,7 @@ namespace Il2CppDumper
         public ulong Address;
         public string Name;
         public string Signature;
+        public string TypeSignature;
     }
 
     public class ScriptString

--- a/Il2CppDumper/Outputs/StructGenerator.cs
+++ b/Il2CppDumper/Outputs/StructGenerator.cs
@@ -141,10 +141,10 @@ namespace Il2CppDumper
                         {
                             foreach (var methodSpec in methodSpecs)
                             {
-                                var methodTypeSignature = new List<Il2CppTypeEnum>();
                                 var genericMethodPointer = il2Cpp.methodSpecGenericMethodPointers[methodSpec];
                                 if (genericMethodPointer > 0)
                                 {
+                                    var methodTypeSignature = new List<Il2CppTypeEnum>();
                                     var scriptMethod = new ScriptMethod();
                                     json.ScriptMethod.Add(scriptMethod);
                                     scriptMethod.Address = il2Cpp.GetRVA(genericMethodPointer);

--- a/Il2CppDumper/Outputs/StructGenerator.cs
+++ b/Il2CppDumper/Outputs/StructGenerator.cs
@@ -89,6 +89,7 @@ namespace Il2CppDumper
                         var methodPointer = il2Cpp.GetMethodPointer(imageName, methodDef);
                         if (methodPointer > 0)
                         {
+                            var methodTypeSignature = new List<Il2CppTypeEnum>();
                             var scriptMethod = new ScriptMethod();
                             json.ScriptMethod.Add(scriptMethod);
                             scriptMethod.Address = il2Cpp.GetRVA(methodPointer);
@@ -101,15 +102,18 @@ namespace Il2CppDumper
                             {
                                 returnType += "*";
                             }
+                            methodTypeSignature.Add(methodReturnType.byref == 1 ? Il2CppTypeEnum.IL2CPP_TYPE_PTR : methodReturnType.type);
                             var signature = $"{returnType} {FixName(methodFullName)} (";
                             var parameterStrs = new List<string>();
                             if ((methodDef.flags & METHOD_ATTRIBUTE_STATIC) == 0)
                             {
                                 var thisType = ParseType(il2Cpp.types[typeDef.byvalTypeIndex]);
+                                methodTypeSignature.Add(il2Cpp.types[typeDef.byvalTypeIndex].type);
                                 parameterStrs.Add($"{thisType} __this");
                             }
                             else if (il2Cpp.Version <= 24)
                             {
+                                methodTypeSignature.Add(Il2CppTypeEnum.IL2CPP_TYPE_PTR);
                                 parameterStrs.Add($"Il2CppObject* __this");
                             }
                             for (var j = 0; j < methodDef.parameterCount; j++)
@@ -122,18 +126,22 @@ namespace Il2CppDumper
                                 {
                                     parameterCType += "*";
                                 }
+                                methodTypeSignature.Add(parameterType.byref == 1 ? Il2CppTypeEnum.IL2CPP_TYPE_PTR : parameterType.type);
                                 parameterStrs.Add($"{parameterCType} {FixName(parameterName)}");
                             }
+                            methodTypeSignature.Add(Il2CppTypeEnum.IL2CPP_TYPE_PTR);
                             parameterStrs.Add("const MethodInfo* method");
                             signature += string.Join(", ", parameterStrs);
                             signature += ");";
                             scriptMethod.Signature = signature;
+                            scriptMethod.TypeSignature = GetMethodTypeSignature(methodTypeSignature);
                         }
                         //泛型实例函数
                         if (il2Cpp.methodDefinitionMethodSpecs.TryGetValue(i, out var methodSpecs))
                         {
                             foreach (var methodSpec in methodSpecs)
                             {
+                                var methodTypeSignature = new List<Il2CppTypeEnum>();
                                 var genericMethodPointer = il2Cpp.methodSpecGenericMethodPointers[methodSpec];
                                 if (genericMethodPointer > 0)
                                 {
@@ -158,6 +166,7 @@ namespace Il2CppDumper
                                     {
                                         returnType += "*";
                                     }
+                                    methodTypeSignature.Add(methodReturnType.byref == 1 ? Il2CppTypeEnum.IL2CPP_TYPE_PTR : methodReturnType.type);
                                     var signature = $"{returnType} {FixName(methodFullName)} (";
                                     var parameterStrs = new List<string>();
                                     if ((methodDef.flags & METHOD_ATTRIBUTE_STATIC) == 0)
@@ -172,21 +181,25 @@ namespace Il2CppDumper
                                             if (nameGenericClassDic.TryGetValue(typeStructName, out var il2CppType))
                                             {
                                                 thisType = ParseType(il2CppType);
+                                                methodTypeSignature.Add(il2CppType.type);
                                             }
                                             else
                                             {
                                                 //没有单独的泛型实例类
                                                 thisType = ParseType(il2Cpp.types[typeDef.byvalTypeIndex]);
+                                                methodTypeSignature.Add(il2Cpp.types[typeDef.byvalTypeIndex].type);
                                             }
                                         }
                                         else
                                         {
                                             thisType = ParseType(il2Cpp.types[typeDef.byvalTypeIndex]);
+                                            methodTypeSignature.Add(il2Cpp.types[typeDef.byvalTypeIndex].type);
                                         }
                                         parameterStrs.Add($"{thisType} __this");
                                     }
                                     else if (il2Cpp.Version <= 24)
                                     {
+                                        methodTypeSignature.Add(Il2CppTypeEnum.IL2CPP_TYPE_PTR);
                                         parameterStrs.Add($"Il2CppObject* __this");
                                     }
                                     for (var j = 0; j < methodDef.parameterCount; j++)
@@ -199,12 +212,15 @@ namespace Il2CppDumper
                                         {
                                             parameterCType += "*";
                                         }
+                                        methodTypeSignature.Add(parameterType.byref == 1 ? Il2CppTypeEnum.IL2CPP_TYPE_PTR : parameterType.type);
                                         parameterStrs.Add($"{parameterCType} {FixName(parameterName)}");
                                     }
+                                    methodTypeSignature.Add(Il2CppTypeEnum.IL2CPP_TYPE_PTR);
                                     parameterStrs.Add($"const {methodInfoName}* method");
                                     signature += string.Join(", ", parameterStrs);
                                     signature += ");";
                                     scriptMethod.Signature = signature;
+                                    scriptMethod.TypeSignature = GetMethodTypeSignature(methodTypeSignature);
                                 }
                             }
                         }
@@ -643,6 +659,57 @@ namespace Il2CppDumper
                 default:
                     throw new NotSupportedException();
             }
+        }
+        public string GetMethodTypeSignature(List<Il2CppTypeEnum> types)
+        {
+            string signature = string.Empty;
+            foreach (Il2CppTypeEnum type in types)
+            {
+                switch (type)
+                {
+                    case Il2CppTypeEnum.IL2CPP_TYPE_VOID:
+                        signature += "v";
+                        break;
+                    case Il2CppTypeEnum.IL2CPP_TYPE_BOOLEAN:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_CHAR:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_I1:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_U1:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_I2:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_U2:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_I4:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_U4:
+                        signature += "i";
+                        break;
+                    case Il2CppTypeEnum.IL2CPP_TYPE_I8:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_U8:
+                        signature += "j";
+                        break;
+                    case Il2CppTypeEnum.IL2CPP_TYPE_R4:
+                        signature += "f";
+                        break;
+                    case Il2CppTypeEnum.IL2CPP_TYPE_R8:
+                        signature += "d";
+                        break;
+                    case Il2CppTypeEnum.IL2CPP_TYPE_STRING:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_PTR:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_VALUETYPE:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_CLASS:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_VAR:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_ARRAY:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_GENERICINST:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_TYPEDBYREF:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_I:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_U:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_OBJECT:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_SZARRAY:
+                    case Il2CppTypeEnum.IL2CPP_TYPE_MVAR:
+                        signature += "i";
+                        break;
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+            return signature;
         }
 
         private void AddStruct(Il2CppTypeDefinition typeDef)

--- a/Il2CppDumper/ghidra_wasm.py
+++ b/Il2CppDumper/ghidra_wasm.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+import json
+
+from wasm import WasmLoader
+from wasm.analysis import WasmAnalysis
+from ghidra.util.task import ConsoleTaskMonitor
+
+monitor = ConsoleTaskMonitor()
+WasmLoader.loadElementsToTable(currentProgram, WasmAnalysis.getState(currentProgram).module, 0, 0, 0, monitor)
+
+runScript("analyze_dyncalls.py")
+
+processFields = [
+	"ScriptMethod",
+	"ScriptString",
+	"ScriptMetadata",
+	"ScriptMetadataMethod",
+	"Addresses",
+]
+
+functionManager = currentProgram.getFunctionManager()
+progspace = currentProgram.addressFactory.getAddressSpace("ram")
+USER_DEFINED = ghidra.program.model.symbol.SourceType.USER_DEFINED
+
+def get_addr(addr):
+	return progspace.getAddress(addr)
+
+def set_name(addr, name):
+	name = name.replace(' ', '-')
+	createLabel(addr, name, True, USER_DEFINED)
+
+def make_function(start):
+	func = getFunctionAt(start)
+	if func is None:
+		createFunction(start, None)
+
+f = askFile("script.json from Il2cppdumper", "Open")
+data = json.loads(open(f.absolutePath, 'rb').read().decode('utf-8'))
+
+
+if "ScriptMethod" in data and "ScriptMethod" in processFields:
+	scriptMethods = data["ScriptMethod"]
+	dynCallNamespace =  currentProgram.symbolTable.getNamespace("dynCall", None)
+	monitor.initialize(len(scriptMethods))
+	monitor.setMessage("Methods")
+	for scriptMethod in scriptMethods:
+		offset = scriptMethod["Address"]
+		sig = scriptMethod["TypeSignature"]
+		symbolName = "func_%s_%d" % (sig, offset)
+		symbol = currentProgram.symbolTable.getSymbol(symbolName, dynCallNamespace)
+		if symbol:
+			addr = symbol.address
+			name = scriptMethod["Name"].encode("utf-8")
+			set_name(addr, name)
+		else:
+			print "Warning at %s:" % scriptMethod["Name"]
+			print "Symbol %s not found!" % symbolName
+		monitor.incrementProgress(1)
+
+if "ScriptString" in data and "ScriptString" in processFields:
+	index = 1
+	scriptStrings = data["ScriptString"]
+	monitor.initialize(len(scriptStrings))
+	monitor.setMessage("Strings")
+	for scriptString in scriptStrings:
+		addr = get_addr(scriptString["Address"])
+		value = scriptString["Value"].encode("utf-8")
+		name = "StringLiteral_" + str(index)
+		createLabel(addr, name, True, USER_DEFINED)
+		setEOLComment(addr, value)
+		index += 1
+		monitor.incrementProgress(1)
+
+if "ScriptMetadata" in data and "ScriptMetadata" in processFields:
+	scriptMetadatas = data["ScriptMetadata"]
+	monitor.initialize(len(scriptMetadatas))
+	monitor.setMessage("Metadata")
+	for scriptMetadata in scriptMetadatas:
+		addr = get_addr(scriptMetadata["Address"])
+		name = scriptMetadata["Name"].encode("utf-8")
+		set_name(addr, name)
+		setEOLComment(addr, name)
+		monitor.incrementProgress(1)
+
+if "ScriptMetadataMethod" in data and "ScriptMetadataMethod" in processFields:
+	scriptMetadataMethods = data["ScriptMetadataMethod"]
+	monitor.initialize(len(scriptMetadataMethods))
+	monitor.setMessage("Metadata Methods")
+	for scriptMetadataMethod in scriptMetadataMethods:
+		addr = get_addr(scriptMetadataMethod["Address"])
+		name = scriptMetadataMethod["Name"].encode("utf-8")
+		methodAddr = get_addr(scriptMetadataMethod["MethodAddress"])
+		set_name(addr, name)
+		setEOLComment(addr, name)
+		monitor.incrementProgress(1)
+
+if "Addresses" in data and "Addresses" in processFields:
+	pass
+
+print 'Script finished!'

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ structure information header file
 
 For Ghidra
 
+#### ghidra_wasm.py
+
+For Ghidra, work with [ghidra-wasm-plugin](https://github.com/nneonneo/ghidra-wasm-plugin)
+
 #### script.json
 
 For ida.py and ghidra.py

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,6 +52,10 @@ Il2CppDumper.exe <executable-file> <global-metadata> <output-directory>
 
 用于Ghidra
 
+#### ghidra_wasm.py
+
+用于Ghidra, 和[ghidra-wasm-plugin](https://github.com/nneonneo/ghidra-wasm-plugin)一起工作
+
 #### script.json
 
 用于IDA和Ghidra脚本


### PR DESCRIPTION
添加 ghidra_wasm.py 脚本，根据 script.json 的内容恢复 wasm 中的符号信息。

测试结果：

![](https://user-images.githubusercontent.com/21212051/144026160-afa43ea1-022d-434e-808e-d75f57520aba.png)

测试文件：

[Build.zip](https://github.com/Perfare/Il2CppDumper/files/7624829/Build.zip)
