### PR TITLE
Fixed compatibility with ghidra's vanilla python interpreter. Added more error handling

### DIFF
--- a/Il2CppDumper/ghidra_with_struct.py
+++ b/Il2CppDumper/ghidra_with_struct.py
@@ -20,8 +20,11 @@ def get_addr(addr):
 	return baseAddress.add(addr)
 
 def set_name(addr, name):
-	name = name.replace(' ', '-')
-	createLabel(addr, name, True, USER_DEFINED)
+    try:
+        name = name.replace(' ', '-')
+        createLabel(addr, name, True, USER_DEFINED)
+    except:
+        print("set_name() Failed.")
 
 def set_type(addr, type):
 	# Requires types (il2cpp.h) to be imported first
@@ -47,15 +50,16 @@ def set_type(addr, type):
 	    try:
 	        createData(addr, addrType)
 	    except ghidra.program.model.util.CodeUnitInsertionException:
-	        print("Warning: unable to set type")
-            print(type + "at address" + addr + "(CodeUnitInsertionException)")
-            print("Skipping.")
+	        print("Warning: unable to set type (CodeUnitInsertionException)")
 	    
 
 def make_function(start):
 	func = getFunctionAt(start)
 	if func is None:
-		createFunction(start, None)
+		try:
+			createFunction(start, None)
+		except:
+			print("Warning: Unable to create function")
 
 def set_sig(addr, name, sig):
 	try: 
@@ -74,8 +78,11 @@ def set_sig(addr, name, sig):
 			print("Skipping.")
 			return
 	if typeSig is not None:
-		typeSig.setName(name)
-		ApplyFunctionSignatureCmd(addr, typeSig, USER_DEFINED, False, True).applyTo(currentProgram)
+		try:
+            		typeSig.setName(name)
+            		ApplyFunctionSignatureCmd(addr, typeSig, USER_DEFINED, False, True).applyTo(currentProgram)
+		except:
+			print("Warning: unable to set Signature. ApplyFunctionSignatureCmd() Failed.")
 
 f = askFile("script.json from Il2cppdumper", "Open")
 data = json.loads(open(f.absolutePath, 'rb').read().decode('utf-8'))

--- a/Il2CppDumper/ghidra_with_struct.py
+++ b/Il2CppDumper/ghidra_with_struct.py
@@ -44,7 +44,13 @@ def set_type(addr, type):
 	if addrType is None:
 		print("Could not identify type " + type + "(parsed as '" + newType + "')")
 	else:
-		createData(addr, addrType)
+	    try:
+	        createData(addr, addrType)
+	    except ghidra.program.model.util.CodeUnitInsertionException:
+	        print("Warning: unable to set type")
+            print(type + "at address" + addr + "(CodeUnitInsertionException)")
+            print("Skipping.")
+	    
 
 def make_function(start):
 	func = getFunctionAt(start)

--- a/Il2CppDumper/il2cpp_header_to_ghidra.py
+++ b/Il2CppDumper/il2cpp_header_to_ghidra.py
@@ -1,0 +1,36 @@
+﻿import re
+
+header = "typedef unsigned __int8 uint8_t;\n" \
+         "typedef unsigned __int16 uint16_t;\n" \
+         "typedef unsigned __int32 uint32_t;\n" \
+         "typedef unsigned __int64 uint64_t;\n" \
+         "typedef __int8 int8_t;\n" \
+         "typedef __int16 int16_t;\n" \
+         "typedef __int32 int32_t;\n" \
+         "typedef __int64 int64_t;\n" \
+         "typedef __int64 intptr_t;\n" \
+         "typedef __int64 uintptr_t;\n" \
+         "typedef unsigned __int64 size_t;\n"
+
+
+def main():
+    fixed_header_data = ""
+    with open("il2cpp.h", 'r') as f:
+        print("il2cpp.h opened...")
+        original_header_data = f.read()
+        print("il2cpp.h read...")
+        fixed_header_data = re.sub(r": (\w+) {", r"{\n \1 super;", original_header_data)
+        print("il2cpp.h data fixed...")
+    print("il2cpp.h closed.")
+    with open("il2cpp_ghidra.h", 'w') as f:
+        print("il2cpp_ghidra.h opened...")
+        f.write(header)
+        print("header written...")
+        f.write(fixed_header_data)
+        print("fixed data written...")
+    print("il2cpp_ghidra.h closed.")
+
+
+if __name__ == '__main__':
+    print("Script started...")
+    main()


### PR DESCRIPTION
Ghidra has lots of special exceptions and will quit the script upon encountering them. I added better error handling here.
I also made the script compatible with the vanilla (unmodified) python interpreter, including some code style issues, like needing 6 space indents after some try/except statements.

Removed the address specification for setting types as, again, ghidra's vanilla python interpreter has compatibility issues.

The AppVeyor build issue is this change:
![image](https://user-images.githubusercontent.com/70150617/145844796-dc5baa0a-3a00-423a-9144-7039a70aa35c.png)
