### PR TITLE
Fix ghidra_wasm.py compatibility issue with ghidra 10.1

### DIFF
--- a/Il2CppDumper/ghidra_wasm.py
+++ b/Il2CppDumper/ghidra_wasm.py
@@ -47,9 +47,9 @@ if "ScriptMethod" in data and "ScriptMethod" in processFields:
 		offset = scriptMethod["Address"]
 		sig = scriptMethod["TypeSignature"]
 		symbolName = "func_%s_%d" % (sig, offset)
-		symbol = currentProgram.symbolTable.getSymbol(symbolName, dynCallNamespace)
-		if symbol:
-			addr = symbol.address
+		symbol = currentProgram.symbolTable.getSymbols(symbolName, dynCallNamespace)
+		if len(symbol) > 0:
+			addr = symbol[0].address
 			name = scriptMethod["Name"].encode("utf-8")
 			set_name(addr, name)
 		else:


### PR DESCRIPTION
## Issue
Ghidra v10.1 removed `getSymbol(String, Namespace)` api (https://github.com/NationalSecurityAgency/ghidra/commit/d05a57ae1a90ae11a9f196dbcd48c74ff7252b34), which crashes the script.

## Fix
According to [this line](https://github.com/NationalSecurityAgency/ghidra/commit/d05a57ae1a90ae11a9f196dbcd48c74ff7252b34#diff-8df1a461bea224897255796fe5bc89a59ae6e099f4dc5c16bb4521b1ae05e695L199), simply use `getSymbols(String, Namespace)` instead works like a charm.
 
