### PR TITLE
Add bool typedef to il2cpp_header_to_ghidra.py

### DIFF
--- a/Il2CppDumper/il2cpp_header_to_ghidra.py
+++ b/Il2CppDumper/il2cpp_header_to_ghidra.py
@@ -10,7 +10,8 @@ header = "typedef unsigned __int8 uint8_t;\n" \
          "typedef __int64 int64_t;\n" \
          "typedef __int64 intptr_t;\n" \
          "typedef __int64 uintptr_t;\n" \
-         "typedef unsigned __int64 size_t;\n"
+         "typedef unsigned __int64 size_t;\n" \
+         "typedef _Bool bool;\n"
 
 
 def main():


### PR DESCRIPTION
Harmony's Odyssey is using bools and since "bool" macro is not a part of C89, I have added proper typedef.

Btw. I think you should edit script to allow choosing file from other than root folder for reading and saving - since root path is not easily deducable. I have edited it on my PC but i don't know how to set default file name in case of saving file.