### PR TITLE
add function index for script.json (WASM)

### DIFF
--- a/Il2CppDumper/ExecutableFormats/WebAssemblyMemory.cs
+++ b/Il2CppDumper/ExecutableFormats/WebAssemblyMemory.cs
@@ -79,7 +79,7 @@ namespace Il2CppDumper
             // on wasm, address of function is actually index of reference table.
             // reference table points index of function at runtime.
             // (e.g. if a function has address 123 and refTable[123] is 456, it will be $func456)
-            return refTable != null && address < (ulong)refTable.Length ? (int)refTable[address] : -1;
+            return refTable != null && address < (ulong)refTable.Length ? (int)refTable[address] : 0;
         }
     }
 }

--- a/Il2CppDumper/ExecutableFormats/WebAssemblyMemory.cs
+++ b/Il2CppDumper/ExecutableFormats/WebAssemblyMemory.cs
@@ -5,11 +5,13 @@ namespace Il2CppDumper
     public sealed class WebAssemblyMemory : Il2Cpp
     {
         private readonly uint bssStart;
+        private readonly uint[] refTable;
 
-        public WebAssemblyMemory(Stream stream, uint bssStart) : base(stream)
+        public WebAssemblyMemory(Stream stream, uint bssStart, uint[] funcRefs) : base(stream)
         {
             Is32Bit = true;
             this.bssStart = bssStart;
+            this.refTable = funcRefs;
         }
 
         public override ulong MapVATR(ulong addr)
@@ -71,5 +73,13 @@ namespace Il2CppDumper
         }
 
         public override bool CheckDump() => false;
+
+        public override int GetFunctionIndex(ulong address)
+        {
+            // on wasm, address of function is actually index of reference table.
+            // reference table points index of function at runtime.
+            // (e.g. if a function has address 123 and refTable[123] is 456, it will be $func456)
+            return refTable != null && address < (ulong)refTable.Length ? (int)refTable[address] : -1;
+        }
     }
 }

--- a/Il2CppDumper/Il2Cpp/Il2Cpp.cs
+++ b/Il2CppDumper/Il2Cpp/Il2Cpp.cs
@@ -332,5 +332,10 @@ namespace Il2CppDumper
         {
             return pointer;
         }
+
+        public virtual int GetFunctionIndex(ulong pointer)
+        {
+            return -1;
+        }
     }
 }

--- a/Il2CppDumper/Il2Cpp/Il2Cpp.cs
+++ b/Il2CppDumper/Il2Cpp/Il2Cpp.cs
@@ -335,7 +335,7 @@ namespace Il2CppDumper
 
         public virtual int GetFunctionIndex(ulong pointer)
         {
-            return -1;
+            return 0;
         }
     }
 }

--- a/Il2CppDumper/Outputs/ScriptJson.cs
+++ b/Il2CppDumper/Outputs/ScriptJson.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Il2CppDumper
 {
@@ -14,15 +15,11 @@ namespace Il2CppDumper
     public class ScriptMethod
     {
         public ulong Address;
-        public int Index = -1;
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public int Index;
         public string Name;
         public string Signature;
         public string TypeSignature;
-
-        public bool ShouldSerializeIndex()
-        {
-            return Index != -1;
-        }
     }
 
     public class ScriptString

--- a/Il2CppDumper/Outputs/ScriptJson.cs
+++ b/Il2CppDumper/Outputs/ScriptJson.cs
@@ -14,9 +14,15 @@ namespace Il2CppDumper
     public class ScriptMethod
     {
         public ulong Address;
+        public int Index = -1;
         public string Name;
         public string Signature;
         public string TypeSignature;
+
+        public bool ShouldSerializeIndex()
+        {
+            return Index != -1;
+        }
     }
 
     public class ScriptString

--- a/Il2CppDumper/Outputs/StructGenerator.cs
+++ b/Il2CppDumper/Outputs/StructGenerator.cs
@@ -93,6 +93,7 @@ namespace Il2CppDumper
                             var scriptMethod = new ScriptMethod();
                             json.ScriptMethod.Add(scriptMethod);
                             scriptMethod.Address = il2Cpp.GetRVA(methodPointer);
+                            scriptMethod.Index = il2Cpp.GetFunctionIndex(methodPointer);
                             var methodFullName = typeName + "$$" + methodName;
                             scriptMethod.Name = methodFullName;
 
@@ -148,6 +149,7 @@ namespace Il2CppDumper
                                     var scriptMethod = new ScriptMethod();
                                     json.ScriptMethod.Add(scriptMethod);
                                     scriptMethod.Address = il2Cpp.GetRVA(genericMethodPointer);
+                                    scriptMethod.Index = il2Cpp.GetFunctionIndex(genericMethodPointer);
                                     var methodInfoName = $"MethodInfo_{scriptMethod.Address:X}";
                                     var structTypeName = structNameDic[typeDef];
                                     var rgctxs = GenerateRGCTX(imageName, methodDef);


### PR DESCRIPTION
It seems you already know this, but in WASM the address of a function is actually the index of its reference table. However, this can be confusing if you're not familiar with the WASM specifications. This PR aims to make it easy by adding a function index to the script.json.
For instance, a function with index 123 will be $func123 at runtime.