### PR TITLE
il2cpp_header_to_ghidra.py: Allow loading and saving from any place + replace keywords

### DIFF
--- a/Il2CppDumper/il2cpp_header_to_ghidra.py
+++ b/Il2CppDumper/il2cpp_header_to_ghidra.py
@@ -72,7 +72,7 @@ replace_keywords = [
     " unsigned;",
     " void;",
     " volatile;",
-    " while;",
+    " while;"
 ]
 
 

--- a/Il2CppDumper/il2cpp_header_to_ghidra.py
+++ b/Il2CppDumper/il2cpp_header_to_ghidra.py
@@ -55,7 +55,7 @@ replace_keywords = [
     " restrict;",
     " return;",
     " short;",
-    " signed;";
+    " signed;",
     " _signed;",
     " __signed;",
     " sizeof;",

--- a/Il2CppDumper/il2cpp_header_to_ghidra.py
+++ b/Il2CppDumper/il2cpp_header_to_ghidra.py
@@ -1,4 +1,4 @@
-﻿import re
+import re
 
 header = "typedef unsigned __int8 uint8_t;\n" \
          "typedef unsigned __int16 uint16_t;\n" \
@@ -13,23 +13,100 @@ header = "typedef unsigned __int8 uint8_t;\n" \
          "typedef unsigned __int64 size_t;\n" \
          "typedef _Bool bool;\n"
 
+replace_keywords = [
+    " alignas;",
+    " _Alignas;",
+    " alignof;",
+    " _Alignof;",
+    " _Atomic;",
+    " auto;",
+    " _BitInt;",
+    " bool;",
+    " _Bool;",
+    " break;",
+    " case;",
+    " char;",
+    " _Complex;",
+    " const;",
+    " constexpr;",
+    " continue;",
+    " _Decimal128;",
+    " _Decimal32;",
+    " _Decimal64;",
+    " default;",
+    " do;",
+    " double;",
+    " else;",
+    " enum;",
+    " extern;",
+    " false;",
+    " float;",
+    " for;",
+    " _Generic;",
+    " goto;",
+    " if;",
+    " _Imaginary;",
+    " inline;",
+    " int;",
+    " long;",
+    " _Noreturn;",
+    " nullptr;",
+    " register;",
+    " restrict;",
+    " return;",
+    " short;",
+    " signed;",
+    " sizeof;",
+    " static;",
+    " static_assert;",
+    " _Static_assert;",
+    " struct;",
+    " switch;",
+    " thread_local;",
+    " _Thread_local;",
+    " true;",
+    " typedef;",
+    " typeof;",
+    " typeof_unqual;",
+    " union;",
+    " unsigned;",
+    " void;",
+    " volatile;",
+    " while;",
+]
+
 
 def main():
     fixed_header_data = ""
-    with open("il2cpp.h", 'r') as f:
+    h_file = askFile("il2cpp.h from Il2cppdumper", "Open")
+    with open(h_file.absolutePath, 'r') as f:
         print("il2cpp.h opened...")
         original_header_data = f.read()
         print("il2cpp.h read...")
         fixed_header_data = re.sub(r": (\w+) {", r"{\n \1 super;", original_header_data)
+        for i in range(len(replace_keywords)):
+            if (fixed_header_data.find(replace_keywords[i]) != -1):
+                x = 1
+                while (x < 10):
+                    if (fixed_header_data.find(replace_keywords[i][:1] + ("_" * x) + replace_keywords[i][1:]) == -1):
+                        string = replace_keywords[i][:1] + ("_" * x) + replace_keywords[i][1:]
+                        break
+                    x += 1
+                if (x == 10):
+                    print("Replacing variable name \"%s\" failed..." % (replace_keywords[i][1:-1]))
+                else:
+                    fixed_header_data = fixed_header_data.replace(replace_keywords[i], string)
+                    print("Replace variable name \"%s\" with \"%s\"..." % (replace_keywords[i][1:-1], string[1:-1]))
         print("il2cpp.h data fixed...")
     print("il2cpp.h closed.")
-    with open("il2cpp_ghidra.h", 'w') as f:
-        print("il2cpp_ghidra.h opened...")
+    new_file = askFile("Choose where to save patched il2cpp.h", "Save")
+    with open(new_file.absolutePath, 'w') as f:
+        print("Patched header opened...")
         f.write(header)
-        print("header written...")
+        print("Patched header written...")
         f.write(fixed_header_data)
         print("fixed data written...")
-    print("il2cpp_ghidra.h closed.")
+    print("Patched header closed.")
 
 
 if __name__ == '__main__':

--- a/Il2CppDumper/il2cpp_header_to_ghidra.py
+++ b/Il2CppDumper/il2cpp_header_to_ghidra.py
@@ -72,7 +72,7 @@ replace_keywords = [
     " unsigned;",
     " void;",
     " volatile;",
-    " while;"
+    " while;",
 ]
 
 
@@ -82,31 +82,29 @@ def main():
     with open(h_file.absolutePath, 'r') as f:
         print("il2cpp.h opened...")
         original_header_data = f.read()
-        print("il2cpp.h read...")
-        fixed_header_data = re.sub(r": (\w+) {", r"{\n \1 super;", original_header_data)
-        for i in range(len(replace_keywords)):
-            if (fixed_header_data.find(replace_keywords[i]) != -1):
-                x = 1
-                while (x < 10):
-                    if (fixed_header_data.find(replace_keywords[i][:1] + ("_" * x) + replace_keywords[i][1:]) == -1):
-                        string = replace_keywords[i][:1] + ("_" * x) + replace_keywords[i][1:]
-                        break
-                    x += 1
-                if (x == 10):
-                    print("Replacing variable name \"%s\" failed..." % (replace_keywords[i][1:-1]))
-                else:
-                    fixed_header_data = fixed_header_data.replace(replace_keywords[i], string)
-                    print("Replace variable name \"%s\" with \"%s\"..." % (replace_keywords[i][1:-1], string[1:-1]))
-        print("il2cpp.h data fixed...")
-    print("il2cpp.h closed.")
+    print("il2cpp.h read and closed.")
+    fixed_header_data = re.sub(r": (\w+) {", r"{\n \1 super;", original_header_data)
+    for i in range(len(replace_keywords)):
+        if (fixed_header_data.find(replace_keywords[i]) != -1):
+            x = 1
+            while (x < 10):
+                if (fixed_header_data.find(replace_keywords[i][:1] + ("_" * x) + replace_keywords[i][1:]) == -1):
+                    string = replace_keywords[i][:1] + ("_" * x) + replace_keywords[i][1:]
+                    break
+                x += 1
+            if (x == 10):
+                print("Replacing variable name \"%s\" failed..." % (replace_keywords[i][1:-1]))
+            else:
+                fixed_header_data = fixed_header_data.replace(replace_keywords[i], string)
+                print("Replace variable name \"%s\" with \"%s\"..." % (replace_keywords[i][1:-1], string[1:-1]))
+    print("il2cpp.h data fixed...")
     new_file = askFile("Choose where to save patched il2cpp.h", "Save")
     with open(new_file.absolutePath, 'w') as f:
         print("Patched header opened...")
         f.write(header)
-        print("Patched header written...")
+        print("Patched header common typedefs written...")
         f.write(fixed_header_data)
-        print("fixed data written...")
-    print("Patched header closed.")
+    print("Patched header fixed data written and closed...")
 
 
 if __name__ == '__main__':

--- a/Il2CppDumper/il2cpp_header_to_ghidra.py
+++ b/Il2CppDumper/il2cpp_header_to_ghidra.py
@@ -55,7 +55,9 @@ replace_keywords = [
     " restrict;",
     " return;",
     " short;",
-    " signed;",
+    " signed;";
+    " _signed;",
+    " __signed;",
     " sizeof;",
     " static;",
     " static_assert;",


### PR DESCRIPTION
Script now shows window from which user can choose from where they want to load file + window where it should save it.

Also replaces all C keywords if they are used as variable name, by adding "_" at the beginning of name as many times as needed (if 9 is not enough, it skips replacing this name) to not use name that is already in use.

Keywords list taken from here:
https://en.cppreference.com/w/c/keyword

Fixes issue mentioned here:
https://github.com/Perfare/Il2CppDumper/issues/762