### PR TITLE
Warn if `stringLiteralOffset != sizeof(Il2CppGlobalMetadataHeader)`

### DIFF
--- a/Il2CppDumper/Il2Cpp/Metadata.cs
+++ b/Il2CppDumper/Il2Cpp/Metadata.cs
@@ -58,6 +58,10 @@ namespace Il2CppDumper
             }
             Version = version;
             header = ReadClass<Il2CppGlobalMetadataHeader>(0);
+            if (stream.Position != header.stringLiteralOffset)
+            {
+                Console.WriteLine($"WARNING: Metadata header size does not match declared version {version}, version might be incorrect.");
+            }
             if (version == 24)
             {
                 if (header.stringLiteralOffset == 264)


### PR DESCRIPTION
This PR adds extra checks found in Unity-2022.3.0f1:
```c++
bool il2cpp::vm::GlobalMetadata::Initialize(int32_t* imagesCount, int32_t* assembliesCount)
{
    s_GlobalMetadata = vm::MetadataLoader::LoadMetadataFile("global-metadata.dat");
    if (!s_GlobalMetadata)
        return false;

    s_GlobalMetadataHeader = (const Il2CppGlobalMetadataHeader*)s_GlobalMetadata;
    IL2CPP_ASSERT(s_GlobalMetadataHeader->sanity == 0xFAB11BAF);
    IL2CPP_ASSERT(s_GlobalMetadataHeader->version == 29);
    IL2CPP_ASSERT(s_GlobalMetadataHeader->stringLiteralOffset == sizeof(Il2CppGlobalMetadataHeader)); // THIS

    s_MetadataImagesCount = *imagesCount = s_GlobalMetadataHeader->imagesSize / sizeof(Il2CppImageDefinition);
    *assembliesCount = s_GlobalMetadataHeader->assembliesSize / sizeof(Il2CppAssemblyDefinition);
}
```
As both magic number and version are checked with `IL2CPP_ASSERT`, they are not actually enforced at runtime, and may be changed to anything without affecting functionality. I've noticed that there are games in which `global-metadata.dat` does not match the actual IL2CPP version being used, which might confuse users of this tool.

Details can be found in my blog (Chinese): https://reimu.moe/2024/06/09/IL2Cpp-String-Literals/#String-Literals%20%E6%98%AF%E5%A6%82%E4%BD%95%E5%AD%98%E5%82%A8%E7%9A%84%EF%BC%88v27-%EF%BC%89