### PR TITLE
Add config to control whether json values are escaped

### DIFF
--- a/Il2CppDumper/Config.cs
+++ b/Il2CppDumper/Config.cs
@@ -17,5 +17,6 @@
         public double ForceVersion { get; set; } = 24.3;
         public bool ForceDump { get; set; } = false;
         public bool NoRedirectedPointer { get; set; } = false;
+        public bool EscapeJsonValues { get; set; } = false;
     }
 }

--- a/Il2CppDumper/Outputs/StructGenerator.cs
+++ b/Il2CppDumper/Outputs/StructGenerator.cs
@@ -39,7 +39,7 @@ namespace Il2CppDumper
             il2Cpp = il2CppExecutor.il2Cpp;
         }
 
-        public void WriteScript(string outputDir)
+        public void WriteScript(string outputDir, bool escapeJsonValues)
         {
             var json = new ScriptJson();
             // 生成唯一名称
@@ -373,6 +373,10 @@ namespace Il2CppDumper
                 address = $"0x{x.Address:X}"
             }).ToArray();
             var jsonOptions = new JsonSerializerOptions() { WriteIndented = true, IncludeFields = true };
+            if (!escapeJsonValues)
+            {
+                jsonOptions.Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping;
+            }
             File.WriteAllText(outputDir + "stringliteral.json", JsonSerializer.Serialize(stringLiterals, jsonOptions), new UTF8Encoding(false));
             //写入文件
             File.WriteAllText(outputDir + "script.json", JsonSerializer.Serialize(json, jsonOptions));

--- a/Il2CppDumper/Program.cs
+++ b/Il2CppDumper/Program.cs
@@ -262,7 +262,7 @@ namespace Il2CppDumper
             {
                 Console.WriteLine("Generate struct...");
                 var scriptGenerator = new StructGenerator(executor);
-                scriptGenerator.WriteScript(outputDir);
+                scriptGenerator.WriteScript(outputDir, config.EscapeJsonValues);
                 Console.WriteLine("Done!");
             }
             if (config.GenerateDummyDll)

--- a/Il2CppDumper/config.json
+++ b/Il2CppDumper/config.json
@@ -13,5 +13,6 @@
   "ForceIl2CppVersion": false,
   "ForceVersion": 16,
   "ForceDump": false,
-  "NoRedirectedPointer": false
+  "NoRedirectedPointer": false,
+  "EscapeJsonValues": true
 }


### PR DESCRIPTION
This PR adds a new config key `EscapeJsonValues`, which controls whether unicode and special characters are escaped.   
See [UnsafeRelaxedJsonEscaping](https://learn.microsoft.com/en-us/dotnet/api/system.text.encodings.web.javascriptencoder.unsaferelaxedjsonescaping?view=net-8.0#remarks)

The default value for missing the key is `false`, which makes the new version of `Il2cppDumper` behaves the same as old version prior to [this change](https://github.com/Perfare/Il2CppDumper/commit/27a59de4a58f9032351f283fcd19dadcfd43ef2b#diff-ec4481ce2cb1ceec4779271bae9c64ebf0a70965f793fb019a35ecee64fe85e9)