### PR TITLE
Added: Dll name in Dump.cs for Better Understanding

### DIFF
--- a/Il2CppDumper/Outputs/Il2CppDecompiler.cs
+++ b/Il2CppDumper/Outputs/Il2CppDecompiler.cs
@@ -59,7 +59,9 @@ namespace Il2CppDumper
                                 extends.Add(executor.GetTypeName(@interface, false, false));
                             }
                         }
-                        writer.Write($"\n// Namespace: {metadata.GetStringFromIndex(typeDef.namespaceIndex)}\n");
+
+                        writer.Write($"\n// DLL: {imageName}");
+                        writer.Write($"\n// Namespace: `{metadata.GetStringFromIndex(typeDef.namespaceIndex)}`\n");
                         if (config.DumpAttribute)
                         {
                             writer.Write(GetCustomAttribute(imageDef, typeDef.customAttributeIndex, typeDef.token));
@@ -499,3 +501,4 @@ namespace Il2CppDumper
         }
     }
 }
+


### PR DESCRIPTION
Added dll Name in dump.cs with classes for better understanding. 
been using tool since 5-6 years now, and i felt like this was a missing feature. 


OLD output:

// Namespace: 
private sealed class BigInteger.Kernel // TypeDefIndex: 79
{
// Namespace: Mono.Security.Cryptography
internal class DSAManaged : DSA // TypeDefIndex: 76
{

NEW OUTPUT: 

// DLL: mscorlib.dll
// Namespace: ``
private sealed class BigInteger.Kernel // TypeDefIndex: 79
{

 // DLL: mscorlib.dll
// Namespace: `Mono.Security.Cryptography`
internal class DSAManaged : DSA // TypeDefIndex: 76
{