### PR TITLE
support replace hashed class name by config

### DIFF
--- a/Il2CppDumper/Config.cs
+++ b/Il2CppDumper/Config.cs
@@ -1,5 +1,14 @@
-﻿namespace Il2CppDumper
+﻿using System.Collections.Generic;
+
+namespace Il2CppDumper
 {
+
+    public class ReplaceHashName
+    {
+        public string TargetName { get; set; }
+        public string ReplaceToName { get; set; }
+    }
+
     public class Config
     {
         public bool DumpMethod { get; set; } = true;
@@ -17,5 +26,7 @@
         public double ForceVersion { get; set; } = 24.3;
         public bool ForceDump { get; set; } = false;
         public bool NoRedirectedPointer { get; set; } = false;
-    }
+        public List<ReplaceHashName> ReplaceHashNames { get; set; }
+        public Dictionary<string, string> ReplaceHashNameMap { get; set; }
+}
 }

--- a/Il2CppDumper/Il2Cpp/Metadata.cs
+++ b/Il2CppDumper/Il2Cpp/Metadata.cs
@@ -182,6 +182,17 @@ namespace Il2CppDumper
             if (!stringCache.TryGetValue(index, out var result))
             {
                 result = ReadStringToNull(header.stringOffset + index);
+
+                string szReplaceToName = null;
+                if (result != null)
+                {
+                    szReplaceToName = Il2CppDumper.Program.TryGetReplaceName(result);
+                }
+                if (szReplaceToName != null)
+                {
+                    result = szReplaceToName;
+                }
+
                 stringCache.Add(index, result);
             }
             return result;

--- a/Il2CppDumper/Program.cs
+++ b/Il2CppDumper/Program.cs
@@ -14,6 +14,7 @@ namespace Il2CppDumper
         static void Main(string[] args)
         {
             config = JsonSerializer.Deserialize<Config>(File.ReadAllText(AppDomain.CurrentDomain.BaseDirectory + @"config.json"));
+            GenerateReplaceNameMap();
             string il2cppPath = null;
             string metadataPath = null;
             string outputDir = null;
@@ -109,6 +110,28 @@ namespace Il2CppDumper
                 Console.WriteLine("Press any key to exit...");
                 Console.ReadKey(true);
             }
+        }
+
+        static void GenerateReplaceNameMap()
+        {
+            if (config.ReplaceHashNames != null && config.ReplaceHashNames.Count > 0)
+            {
+                config.ReplaceHashNameMap = new System.Collections.Generic.Dictionary<string, string>();
+                for (int i = 0; i < config.ReplaceHashNames.Count; i++)
+                {
+                    config.ReplaceHashNameMap.Add(config.ReplaceHashNames[i].TargetName, config.ReplaceHashNames[i].ReplaceToName);
+                }
+            }
+        }
+
+        public static string TryGetReplaceName(string szTargetName)
+        {
+            string szRet = null;
+            if(config.ReplaceHashNameMap != null)
+            {
+                config.ReplaceHashNameMap.TryGetValue(szTargetName, out szRet);
+            }
+            return szRet;
         }
 
         static void ShowHelp()

--- a/Il2CppDumper/config.json
+++ b/Il2CppDumper/config.json
@@ -13,5 +13,8 @@
   "ForceIl2CppVersion": false,
   "ForceVersion": 16,
   "ForceDump": false,
-  "NoRedirectedPointer": false
+  "NoRedirectedPointer": false,
+  "ReplaceHashNames": [
+
+  ]
 }


### PR DESCRIPTION
Some games will hash designated class names or function names prior to build packaging. This commit enables manual restoration of original names via configuration (if the correct names are known)