### PR TITLE
fix ghidra script non-ASCII character error

### DIFF
--- a/Il2CppDumper/ghidra.py
+++ b/Il2CppDumper/ghidra.py
@@ -34,7 +34,7 @@ if "ScriptMethod" in data and "ScriptMethod" in processFields:
 	monitor.setMessage("Methods")
 	for scriptMethod in scriptMethods:
 		addr = get_addr(scriptMethod["Address"])
-		name = scriptMethod["Name"].encode("utf-8")
+		name = scriptMethod["Name"]
 		set_name(addr, name)
 		monitor.incrementProgress(1)
 
@@ -45,7 +45,7 @@ if "ScriptString" in data and "ScriptString" in processFields:
 	monitor.setMessage("Strings")
 	for scriptString in scriptStrings:
 		addr = get_addr(scriptString["Address"])
-		value = scriptString["Value"].encode("utf-8")
+		value = scriptString["Value"]
 		name = "StringLiteral_" + str(index)
 		createLabel(addr, name, True, USER_DEFINED)
 		setEOLComment(addr, value)
@@ -58,7 +58,7 @@ if "ScriptMetadata" in data and "ScriptMetadata" in processFields:
 	monitor.setMessage("Metadata")
 	for scriptMetadata in scriptMetadatas:
 		addr = get_addr(scriptMetadata["Address"])
-		name = scriptMetadata["Name"].encode("utf-8")
+		name = scriptMetadata["Name"]
 		set_name(addr, name)
 		setEOLComment(addr, name)
 		monitor.incrementProgress(1)
@@ -69,7 +69,7 @@ if "ScriptMetadataMethod" in data and "ScriptMetadataMethod" in processFields:
 	monitor.setMessage("Metadata Methods")
 	for scriptMetadataMethod in scriptMetadataMethods:
 		addr = get_addr(scriptMetadataMethod["Address"])
-		name = scriptMetadataMethod["Name"].encode("utf-8")
+		name = scriptMetadataMethod["Name"]
 		methodAddr = get_addr(scriptMetadataMethod["MethodAddress"])
 		set_name(addr, name)
 		setEOLComment(addr, name)

--- a/Il2CppDumper/ghidra_wasm.py
+++ b/Il2CppDumper/ghidra_wasm.py
@@ -50,7 +50,7 @@ if "ScriptMethod" in data and "ScriptMethod" in processFields:
 		symbol = currentProgram.symbolTable.getSymbols(symbolName, dynCallNamespace)
 		if len(symbol) > 0:
 			addr = symbol[0].address
-			name = scriptMethod["Name"].encode("utf-8")
+			name = scriptMethod["Name"]
 			set_name(addr, name)
 		else:
 			print "Warning at %s:" % scriptMethod["Name"]
@@ -64,7 +64,7 @@ if "ScriptString" in data and "ScriptString" in processFields:
 	monitor.setMessage("Strings")
 	for scriptString in scriptStrings:
 		addr = get_addr(scriptString["Address"])
-		value = scriptString["Value"].encode("utf-8")
+		value = scriptString["Value"]
 		name = "StringLiteral_" + str(index)
 		createLabel(addr, name, True, USER_DEFINED)
 		setEOLComment(addr, value)
@@ -77,7 +77,7 @@ if "ScriptMetadata" in data and "ScriptMetadata" in processFields:
 	monitor.setMessage("Metadata")
 	for scriptMetadata in scriptMetadatas:
 		addr = get_addr(scriptMetadata["Address"])
-		name = scriptMetadata["Name"].encode("utf-8")
+		name = scriptMetadata["Name"]
 		set_name(addr, name)
 		setEOLComment(addr, name)
 		monitor.incrementProgress(1)
@@ -88,7 +88,7 @@ if "ScriptMetadataMethod" in data and "ScriptMetadataMethod" in processFields:
 	monitor.setMessage("Metadata Methods")
 	for scriptMetadataMethod in scriptMetadataMethods:
 		addr = get_addr(scriptMetadataMethod["Address"])
-		name = scriptMetadataMethod["Name"].encode("utf-8")
+		name = scriptMetadataMethod["Name"]
 		methodAddr = get_addr(scriptMetadataMethod["MethodAddress"])
 		set_name(addr, name)
 		setEOLComment(addr, name)

--- a/Il2CppDumper/ghidra_with_struct.py
+++ b/Il2CppDumper/ghidra_with_struct.py
@@ -93,7 +93,7 @@ if "ScriptMethod" in data and "ScriptMethod" in processFields:
 	monitor.setMessage("Methods")
 	for scriptMethod in scriptMethods:
 		addr = get_addr(scriptMethod["Address"])
-		name = scriptMethod["Name"].encode("utf-8")
+		name = scriptMethod["Name"]
 		set_name(addr, name)
 		monitor.incrementProgress(1)
 
@@ -104,7 +104,7 @@ if "ScriptString" in data and "ScriptString" in processFields:
 	monitor.setMessage("Strings")
 	for scriptString in scriptStrings:
 		addr = get_addr(scriptString["Address"])
-		value = scriptString["Value"].encode("utf-8")
+		value = scriptString["Value"]
 		name = "StringLiteral_" + str(index)
 		createLabel(addr, name, True, USER_DEFINED)
 		setEOLComment(addr, value)
@@ -117,12 +117,12 @@ if "ScriptMetadata" in data and "ScriptMetadata" in processFields:
 	monitor.setMessage("Metadata")
 	for scriptMetadata in scriptMetadatas:
 		addr = get_addr(scriptMetadata["Address"])
-		name = scriptMetadata["Name"].encode("utf-8")
+		name = scriptMetadata["Name"]
 		set_name(addr, name)
 		setEOLComment(addr, name)
 		monitor.incrementProgress(1)
 		if scriptMetadata["Signature"]:
-			set_type(addr, scriptMetadata["Signature"].encode("utf-8"))
+			set_type(addr, scriptMetadata["Signature"])
 
 if "ScriptMetadataMethod" in data and "ScriptMetadataMethod" in processFields:
 	scriptMetadataMethods = data["ScriptMetadataMethod"]
@@ -130,7 +130,7 @@ if "ScriptMetadataMethod" in data and "ScriptMetadataMethod" in processFields:
 	monitor.setMessage("Metadata Methods")
 	for scriptMetadataMethod in scriptMetadataMethods:
 		addr = get_addr(scriptMetadataMethod["Address"])
-		name = scriptMetadataMethod["Name"].encode("utf-8")
+		name = scriptMetadataMethod["Name"]
 		methodAddr = get_addr(scriptMetadataMethod["MethodAddress"])
 		set_name(addr, name)
 		setEOLComment(addr, name)
@@ -149,8 +149,8 @@ if "ScriptMethod" in data and "ScriptMethod" in processFields:
 	scriptMethods = data["ScriptMethod"]
 	for scriptMethod in scriptMethods:
 		addr = get_addr(scriptMethod["Address"])
-		sig = scriptMethod["Signature"][:-1].encode("utf-8")
-		name = scriptMethod["Name"].encode("utf-8")
+		sig = scriptMethod["Signature"][:-1]
+		name = scriptMethod["Name"]
 		set_sig(addr, name, sig)
 
 print 'Script finished!'


### PR DESCRIPTION
When passing strings to ghidra functions in ghidra's Python script, Unicode strings must be passed; however, this code passes byte strings, causing an issue where non-ASCII characters are not displayed correctly. This Pull Request resolves this by modifying the code to pass Unicode strings.